### PR TITLE
Add with_resources

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,11 @@
+use serde_json::Error as JsonError;
 use std::error::Error;
 use std::fmt;
-use serde_json::{Error as JsonError};
 
 #[derive(Debug)]
 pub enum HalError {
     Json(JsonError),
-    Custom(String)
+    Custom(String),
 }
 
 pub type HalResult<T> = Result<T, HalError>;
@@ -14,7 +14,7 @@ impl fmt::Display for HalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             HalError::Json(ref e) => write!(f, "JSON Error: {}", e),
-            HalError::Custom(ref s) => write!(f, "Notify error: {}", s)
+            HalError::Custom(ref s) => write!(f, "Notify error: {}", s),
         }
     }
 }
@@ -23,7 +23,7 @@ impl Error for HalError {
     fn description(&self) -> &str {
         match *self {
             HalError::Json(_) => "Error in json processing",
-            HalError::Custom(_) => "Internal Hal Error"
+            HalError::Custom(_) => "Internal Hal Error",
         }
     }
 }
@@ -33,4 +33,3 @@ impl From<JsonError> for HalError {
         HalError::Json(error)
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,17 +47,18 @@
 //! This library is heavily inspired by the [hal-rs](https://github.com/hjr3/hal-rs) library by Herman J. Radtke III.
 //!
 
-extern crate serde_json;
 extern crate serde;
-#[macro_use] extern crate serde_derive;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 
-pub mod resource;
-pub mod link;
 pub mod error;
+pub mod link;
+pub mod resource;
 
-pub use self::resource::HalResource;
-pub use self::link::HalLink;
 pub use self::error::{HalError, HalResult};
+pub use self::link::HalLink;
+pub use self::resource::HalResource;
 
 #[cfg(test)]
 mod tests;

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,9 +1,9 @@
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
-use serde::ser::SerializeMap;
 use serde::de;
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::convert::{From, Into};
+use std::fmt::{Error, Formatter};
 use std::ops::Deref;
-use std::convert::{From,Into};
-use std::fmt::{Error,Formatter};
 
 /// A Link object for linking HAL Resources.
 ///
@@ -90,7 +90,10 @@ macro_rules! chainable_string {
 }
 
 impl HalLink {
-    pub fn new<S>(href: S) -> HalLink where S: Into<String> {
+    pub fn new<S>(href: S) -> HalLink
+    where
+        S: Into<String>,
+    {
         HalLink {
             href: href.into(),
             templated: false,
@@ -114,11 +117,11 @@ impl HalLink {
     chainable_string!(profile, with_profile);
     chainable_string!(title, with_title);
     chainable_string!(hreflang, with_hreflang);
-
 }
 
 impl<T> From<T> for HalLink
-    where T: Into<String>
+where
+    T: Into<String>,
 {
     fn from(s: T) -> Self {
         HalLink::new(s)
@@ -127,9 +130,9 @@ impl<T> From<T> for HalLink
 
 impl Serialize for HalLink {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
-
         let mut len = 1;
         if self.templated {
             len += 1;
@@ -158,7 +161,7 @@ impl Serialize for HalLink {
             try!(state.serialize_key("templated"));
             try!(state.serialize_value(&true));
         }
-        if let Some(ref s) =  self.media_type {
+        if let Some(ref s) = self.media_type {
             try!(state.serialize_key("type"));
             try!(state.serialize_value(s));
         };
@@ -178,7 +181,7 @@ impl Serialize for HalLink {
             try!(state.serialize_key("title"));
             try!(state.serialize_value(s));
         };
-        if let Some(ref s) =  self.hreflang {
+        if let Some(ref s) = self.hreflang {
             try!(state.serialize_key("hreflang"));
             try!(state.serialize_value(s));
         };
@@ -186,12 +189,11 @@ impl Serialize for HalLink {
     }
 }
 
-
 impl<'de> Deserialize<'de> for HalLink {
-
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de> {
-
+    where
+        D: Deserializer<'de>,
+    {
         struct LinkVisitor;
         impl LinkVisitor {
             fn new() -> Self {
@@ -201,14 +203,14 @@ impl<'de> Deserialize<'de> for HalLink {
         /// A visitor for deserializing `HalLink` from map representation, ignoring unknown keys,
         /// and allowing missing fields.
         impl<'de> de::Visitor<'de> for LinkVisitor {
-
             type Value = HalLink;
 
             fn visit_map<M>(self, mut visitor: M) -> Result<HalLink, M::Error>
-                where M: de::MapAccess<'de>
+            where
+                M: de::MapAccess<'de>,
             {
                 let mut link = HalLink::new("");
-                while let Some (key) = try!(visitor.next_key::<String>()) {
+                while let Some(key) = try!(visitor.next_key::<String>()) {
                     if key.deref() == "templated" {
                         link.templated = try!(visitor.next_value());
                     } else {
@@ -219,23 +221,20 @@ impl<'de> Deserialize<'de> for HalLink {
                             "deprecation" => link.deprecation = Some(value),
                             "profile" => link.profile = Some(value),
                             "name" => link.name = Some(value),
-                            "title" =>link.title = Some(value),
+                            "title" => link.title = Some(value),
                             "hreflang" => link.hreflang = Some(value),
-                            &_ => ()
+                            &_ => (),
                         }
                     }
-                };
+                }
                 //try!(visitor.end());
                 Ok(link)
             }
 
-            fn expecting(&self, f: &mut Formatter) -> Result<(), Error>
-            {
+            fn expecting(&self, f: &mut Formatter) -> Result<(), Error> {
                 Ok(())
-
             }
         }
-
 
         deserializer.deserialize_map(LinkVisitor::new())
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -221,36 +221,36 @@ impl HalResource {
         }
     }
 
-    pub fn with_resource(&mut self, name: &str, resource: &HalResource) -> &mut Self {
+    pub fn with_resource(&mut self, name: &str, resource: HalResource) -> &mut Self {
         match self.embedded.entry(name.to_string()) {
             Entry::Vacant(entry) => {
                 let mut resources = OneOrMany::new();
-                resources.push(&resource.clone());
+                resources.push(&resource);
                 entry.insert(resources);
             }
             Entry::Occupied(mut entry) => {
                 let mut content = entry.get_mut(); //&mut HalLinks
-                content.push(&resource.clone());
+                content.push(&resource);
             }
         }
         self
     }
 
-    pub fn with_resources(&mut self, name: &str, resources: Vec<&HalResource>) -> &mut Self {
+    pub fn with_resources(&mut self, name: &str, resources: Vec<HalResource>) -> &mut Self {
         match self.embedded.entry(name.to_string()) {
             Entry::Vacant(entry) => {
                 let mut _resources = OneOrMany::new().force_many();
 
                 for resource in resources.iter() {
-                    _resources.push(resource.clone())
+                    _resources.push(resource)
                 }
-                entry.insert(_resources.clone());
+                entry.insert(_resources);
             }
             Entry::Occupied(mut entry) => {
                 let mut content = entry.get_mut(); //&mut HalLinks
 
                 for resource in resources.iter() {
-                    content.push(&resource.clone());
+                    content.push(&resource);
                 }
             }
         }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,17 +1,17 @@
-use std::collections::*;
 use std::collections::btree_map::Entry;
-use std::vec::*;
+use std::collections::*;
+use std::fmt::{Error as FmtError, Formatter};
 use std::ops::Deref;
-use std::fmt::{Formatter,Error as FmtError};
+use std::vec::*;
 
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
 use serde::de;
 use serde::de::Error;
 use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 //use serde::de::Deserialize;
-use serde_json::{Value as JsonValue, to_value, from_value, Map};
-use super::link::{HalLink};
-use super::{HalError,HalResult};
+use super::link::HalLink;
+use super::{HalError, HalResult};
+use serde_json::{from_value, to_value, Map, Value as JsonValue};
 
 /// A Simple wrapper around a vector to allow custom
 /// serialization when only 1 element is contained.
@@ -42,14 +42,19 @@ use super::{HalError,HalResult};
 #[derive(Clone)]
 pub struct OneOrMany<T> {
     force_many: bool,
-    content: Vec<Box<T>>
+    content: Vec<Box<T>>,
 }
 
-impl<T> OneOrMany<T> where T:Clone {
-
+impl<T> OneOrMany<T>
+where
+    T: Clone,
+{
     /// create a new empty object
     pub fn new() -> OneOrMany<T> {
-        OneOrMany { content: Vec::new(), force_many:false }
+        OneOrMany {
+            content: Vec::new(),
+            force_many: false,
+        }
     }
 
     /// Force to be serialized as array, even if only one element
@@ -89,9 +94,13 @@ impl<T> OneOrMany<T> where T:Clone {
     }
 }
 
-impl<T> Serialize for OneOrMany<T> where T:Serialize+Clone {
+impl<T> Serialize for OneOrMany<T>
+where
+    T: Serialize + Clone,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         if self.is_empty() {
             ().serialize(serializer)
@@ -100,49 +109,48 @@ impl<T> Serialize for OneOrMany<T> where T:Serialize+Clone {
         } else {
             self.content.serialize(serializer)
         }
-
     }
 }
 
-impl<'de,T> Deserialize<'de> for OneOrMany<T> where for<'d> T:Deserialize<'d>+Clone {
+impl<'de, T> Deserialize<'de> for OneOrMany<T>
+where
+    for<'d> T: Deserialize<'d> + Clone,
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
-
-
         let value: JsonValue = try!(Deserialize::deserialize(deserializer));
         let v2 = value.clone();
         match v2 {
             JsonValue::Object(_) => {
                 let obj: T = match from_value(value) {
                     Ok(v) => from_value(v).unwrap(),
-                    Err(e) => return Err(D::Error::custom(format!("JSON Error: {:?}", e)))
+                    Err(e) => return Err(D::Error::custom(format!("JSON Error: {:?}", e))),
                 };
                 let mut res = OneOrMany::new();
                 res.push(&obj);
                 Ok(res)
-            },
+            }
             JsonValue::Array(_) => {
                 let obj: Vec<Box<T>> = match from_value(value) {
                     Ok(v) => from_value(v).unwrap(),
-                    Err(e) => return Err(D::Error::custom(format!("JSON Error: {:?}", e)))
+                    Err(e) => return Err(D::Error::custom(format!("JSON Error: {:?}", e))),
                 };
                 let mut res = OneOrMany::new();
                 res.content = obj;
                 Ok(res)
-            },
-            _ => Ok(OneOrMany::new())
+            }
+            _ => Ok(OneOrMany::new()),
         }
     }
-
 }
 
 /// The HAL Resource structure.
 ///
 ///
 #[derive(Clone)]
-pub struct HalResource
-{
+pub struct HalResource {
     /// Map of links to related resources.
     links: BTreeMap<String, OneOrMany<HalLink>>,
     /// Map of set of embedded resources.
@@ -150,25 +158,26 @@ pub struct HalResource
     /// Documentations Curies
     curies: BTreeMap<String, HalLink>,
     /// The actual resource data
-    data: JsonValue
+    data: JsonValue,
 }
-
 
 impl HalResource {
     pub fn new<T>(payload: T) -> HalResource
-        where T: Serialize
+    where
+        T: Serialize,
     {
         HalResource {
             links: BTreeMap::new(),
             embedded: BTreeMap::new(),
             curies: BTreeMap::new(),
-            data: to_value(payload).unwrap()
+            data: to_value(payload).unwrap(),
         }
     }
 
-    pub fn with_link<S,L>(&mut self, name: S, link: L) -> &mut Self
-        where S: Into<String>,
-              L: Into<HalLink>
+    pub fn with_link<S, L>(&mut self, name: S, link: L) -> &mut Self
+    where
+        S: Into<String>,
+        L: Into<HalLink>,
     {
         let lk_name = name.into();
         match self.links.entry(lk_name.clone()) {
@@ -180,7 +189,7 @@ impl HalResource {
                 }
                 lk.push(&(link.into()));
                 entry.insert(lk);
-            },
+            }
             Entry::Occupied(mut entry) => {
                 let mut content = entry.get_mut(); //&mut HalLinks
                 content.push(&(link.into()));
@@ -193,7 +202,7 @@ impl HalResource {
     pub fn get_link(&self, name: &str) -> Option<&HalLink> {
         match self.links.get(name) {
             Some(link) => link.single(),
-            None => None
+            None => None,
         }
     }
 
@@ -206,18 +215,17 @@ impl HalResource {
     pub fn get_links(&self, name: &str) -> Option<&Vec<Box<HalLink>>> {
         match self.links.get(name) {
             Some(link) => Some(link.many()),
-            None => None
+            None => None,
         }
     }
 
-    pub fn with_resource(&mut self, name: &str, resource: &HalResource) -> &mut Self
-    {
+    pub fn with_resource(&mut self, name: &str, resource: &HalResource) -> &mut Self {
         match self.embedded.entry(name.to_string()) {
             Entry::Vacant(entry) => {
                 let mut resources = OneOrMany::new();
                 resources.push(&resource.clone());
                 entry.insert(resources);
-            },
+            }
             Entry::Occupied(mut entry) => {
                 let mut content = entry.get_mut(); //&mut HalLinks
                 content.push(&resource.clone());
@@ -231,11 +239,14 @@ impl HalResource {
         self
     }
 
-    pub fn with_extra_data<V>(&mut self, name: &str, value: V) -> &mut Self  where V: Serialize{
+    pub fn with_extra_data<V>(&mut self, name: &str, value: V) -> &mut Self
+    where
+        V: Serialize,
+    {
         match self.data {
             JsonValue::Object(ref mut m) => {
                 m.insert(name.to_string(), to_value(value).unwrap());
-            },
+            }
             _ => {
                 let mut data = Map::<String, JsonValue>::new();
                 data.insert(name.to_string(), to_value(value).unwrap());
@@ -246,42 +257,44 @@ impl HalResource {
     }
 
     pub fn get_extra_data<V>(&self, name: &str) -> HalResult<V>
-        where for<'de> V: Deserialize<'de> {
+    where
+        for<'de> V: Deserialize<'de>,
+    {
         let data = match self.data {
             JsonValue::Object(ref m) => m,
-            _ => return Err(HalError::Custom("Invalid payload".to_string()))
+            _ => return Err(HalError::Custom("Invalid payload".to_string())),
         };
         match data.get(name) {
-            Some(v) => {
-                from_value::<V>(v.clone()).or_else(|e| { Err(HalError::Json(e)) })
-            },
-            None => Err(HalError::Custom(format!("Key {} missing in payload", name)))
+            Some(v) => from_value::<V>(v.clone()).or_else(|e| Err(HalError::Json(e))),
+            None => Err(HalError::Custom(format!("Key {} missing in payload", name))),
         }
     }
 
     pub fn get_data<V>(&self) -> HalResult<V>
-        where for <'de> V: Deserialize<'de> {
-        from_value::<V>(self.data.clone()).or_else(|e| { Err(HalError::Json(e)) })
+    where
+        for<'de> V: Deserialize<'de>,
+    {
+        from_value::<V>(self.data.clone()).or_else(|e| Err(HalError::Json(e)))
     }
 }
 
 impl Serialize for HalResource {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
-
         let map = match self.data {
             JsonValue::Object(ref m) => Some(m),
-            _ => None
+            _ => None,
         };
         let mut length = match map {
             Some(m) => m.len(),
-            _ => 0
+            _ => 0,
         };
         length += self.links.len();
         length += self.embedded.len();
 
-        let mut state = try!(serializer.serialize_map(Some(length) ));
+        let mut state = try!(serializer.serialize_map(Some(length)));
         if !self.links.is_empty() {
             try!(state.serialize_key("_links"));
             try!(state.serialize_value(&(self.links)));
@@ -291,7 +304,7 @@ impl Serialize for HalResource {
             try!(state.serialize_value(&(self.embedded)));
         }
         if let Some(map) = map {
-            for (k,v) in map {
+            for (k, v) in map {
                 try!(state.serialize_key(k));
                 try!(state.serialize_value(v));
             }
@@ -301,17 +314,16 @@ impl Serialize for HalResource {
     }
 }
 
-impl<'de> Deserialize<'de> for HalResource  {
-
+impl<'de> Deserialize<'de> for HalResource {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de> {
+    where
+        D: Deserializer<'de>,
+    {
+        struct ResourceVisitor {}
 
-        struct ResourceVisitor {
-        }
-
-        impl ResourceVisitor  {
+        impl ResourceVisitor {
             fn new() -> Self {
-                ResourceVisitor { }
+                ResourceVisitor {}
             }
         }
 
@@ -321,33 +333,32 @@ impl<'de> Deserialize<'de> for HalResource  {
         /// as usual, and stores everything else in  a `JsonValue` object.
         /// It then converts the `JsonValue` to the type T
         impl<'de> de::Visitor<'de> for ResourceVisitor {
-
             type Value = HalResource;
-            fn expecting(&self, f: &mut Formatter) ->Result<(), FmtError>
-            {
+            fn expecting(&self, f: &mut Formatter) -> Result<(), FmtError> {
                 Ok(())
             }
 
             fn visit_map<M>(self, mut visitor: M) -> Result<HalResource, M::Error>
-                where M: de::MapAccess<'de>
+            where
+                M: de::MapAccess<'de>,
             {
                 //transitory Value to read the data.
-                let mut payload : Map<String, JsonValue> = Map::new();
+                let mut payload: Map<String, JsonValue> = Map::new();
                 // Dummy resource to collect the links and embedded resources
                 let mut resource: HalResource = HalResource::new(());
-                while let Some (key) = try!(visitor.next_key::<String>()) {
+                while let Some(key) = try!(visitor.next_key::<String>()) {
                     match key.deref() {
                         "_links" => {
                             resource.links = try!(visitor.next_value());
-                        },
+                        }
                         "_embedded" => {
                             resource.embedded = try!(visitor.next_value());
-                        },
+                        }
                         _ => {
                             payload.insert(key, try!(visitor.next_value()));
                         }
                     }
-                };
+                }
                 //try!(visitor.end());
                 resource.data = JsonValue::Object(payload);
                 Ok(resource)
@@ -356,11 +367,9 @@ impl<'de> Deserialize<'de> for HalResource  {
 
         deserializer.deserialize_map(ResourceVisitor::new())
     }
-
 }
 
-impl PartialEq for HalResource
-{
+impl PartialEq for HalResource {
     fn eq(&self, other: &HalResource) -> bool {
         self.get_self() == other.get_self()
     }

--- a/src/tests/link.rs
+++ b/src/tests/link.rs
@@ -1,6 +1,6 @@
 //use serde::de::Deserialize;
-use serde_json::{from_str};
-use super::super::link::{HalLink};
+use super::super::link::HalLink;
+use serde_json::from_str;
 
 #[test]
 fn ensure_href_gets_deserialized() {
@@ -17,7 +17,8 @@ fn ensure_templated_gets_deserialized() {
 
 #[test]
 fn ensure_full_link_gets_deserialized() {
-    let link : HalLink = from_str(r#"
+    let link: HalLink = from_str(
+        r#"
 {
    "href": "https://www.google.com",
    "name": "google",
@@ -25,16 +26,16 @@ fn ensure_full_link_gets_deserialized() {
    "hreflang": "en-US",
    "deprecation": "https://www.google.com/deprecation",
    "title": "Google Search"
-}"#).unwrap();
+}"#,
+    ).unwrap();
 
     assert_eq!(link.href, "https://www.google.com");
     assert_eq!(link.name, Some("google".to_string()));
     assert_eq!(link.templated, false);
     assert_eq!(link.hreflang, Some("en-US".to_string()));
-    assert_eq!(link.deprecation, Some("https://www.google.com/deprecation".to_string()));
+    assert_eq!(
+        link.deprecation,
+        Some("https://www.google.com/deprecation".to_string())
+    );
     assert_eq!(link.title, Some("Google Search".to_string()));
 }
-
-
-
-                                  

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,4 @@
 include!("serde_types.in.rs");
 
-pub mod resource;
 pub mod link;
+pub mod resource;

--- a/src/tests/resource.rs
+++ b/src/tests/resource.rs
@@ -1,7 +1,7 @@
 use super::super::resource::*;
-use serde_json::{to_string, from_str};
 use super::super::HalLink;
 use super::Test1;
+use serde_json::{from_str, to_string};
 
 //#[derive(Serialize, Deserialize)]
 //struct Test1 {
@@ -10,52 +10,66 @@ use super::Test1;
 
 #[test]
 fn check_data_gets_serialized() {
-    let f: HalResource = HalResource::new(Test1 { a: "Test".to_string() });
+    let f: HalResource = HalResource::new(Test1 {
+        a: "Test".to_string(),
+    });
     let s = to_string(&f).unwrap();
     assert_eq!(s, r#"{"a":"Test"}"#);
 }
 
 #[test]
 fn check_link_gets_serialized_without_empty_attributes() {
-
-    let mut f: HalResource = HalResource::new(Test1 { a: "Test".to_string() });
+    let mut f: HalResource = HalResource::new(Test1 {
+        a: "Test".to_string(),
+    });
     f.with_link("self", "https://self.com");
     let s = to_string(&f).unwrap();
-    assert_eq!(s, r#"{"_links":{"self":{"href":"https://self.com"}},"a":"Test"}"#);
-
+    assert_eq!(
+        s,
+        r#"{"_links":{"self":{"href":"https://self.com"}},"a":"Test"}"#
+    );
 }
 
 #[test]
 fn check_link_arrays_get_serialized() {
-    let mut f: HalResource = HalResource::new(Test1 { a: "Test".to_string() });
+    let mut f: HalResource = HalResource::new(Test1 {
+        a: "Test".to_string(),
+    });
     f.with_link("self", "https://self.com")
         .with_link("alfa", "https://self.com/beta")
         .with_link("alfa", "https://self.com/gamma");
     let s = to_string(&f).unwrap();
     assert_eq!(s, r#"{"_links":{"alfa":[{"href":"https://self.com/beta"},{"href":"https://self.com/gamma"}],"self":{"href":"https://self.com"}},"a":"Test"}"#);
-
 }
 
 #[test]
 fn check_links_get_fully_serialized() {
-    let mut f: HalResource = HalResource::new(Test1 { a: "Test".to_string() });
-    f.with_link("self", HalLink::new("https://self.com").with_title("Self Link").with_name("moi").with_deprecation("http://explain.com/why"));
+    let mut f: HalResource = HalResource::new(Test1 {
+        a: "Test".to_string(),
+    });
+    f.with_link(
+        "self",
+        HalLink::new("https://self.com")
+            .with_title("Self Link")
+            .with_name("moi")
+            .with_deprecation("http://explain.com/why"),
+    );
     let s = to_string(&f).unwrap();
     assert_eq!(s, "{\"_links\":{\"self\":{\"href\":\"https://self.com\",\"deprecation\":\"http://explain.com/why\",\"name\":\"moi\",\"title\":\"Self Link\"}},\"a\":\"Test\"}");
 }
 
-
 #[test]
 fn check_embedded_resource_gets_serialized() {
-    let mut r1 = HalResource::new(Test1 { a: "Test2".to_string() });
+    let mut r1 = HalResource::new(Test1 {
+        a: "Test2".to_string(),
+    });
     r1.with_link("self", "https://self2.com");
 
-    let mut f = HalResource::new(Test1 { a: "Test".to_string() });
+    let mut f = HalResource::new(Test1 {
+        a: "Test".to_string(),
+    });
     f.with_link("self", "https://self.com")
-        .with_resource(
-            "child",
-            &r1
-        );
+        .with_resource("child", &r1);
 
     let s = to_string(&f).unwrap();
     let target = "{\"_links\":{\"self\":{\"href\":\"https://self.com\"}},\"_embedded\":{\"child\":{\"_links\":{\"self\":{\"href\":\"https://self2.com\"}},\"a\":\"Test2\"}},\"a\":\"Test\"}";
@@ -64,26 +78,28 @@ fn check_embedded_resource_gets_serialized() {
 
 #[test]
 fn check_curies_get_serialized_in_links() {
-    let mut r1 = HalResource::new(Test1 { a: "Test".to_string() });
+    let mut r1 = HalResource::new(Test1 {
+        a: "Test".to_string(),
+    });
     r1.with_curie("cur", "https://curie.org")
         .with_link("self", "https://self.com");
     let s = to_string(&r1).unwrap();
     let target = "{\"_links\":{\"curies\":[{\"href\":\"https://curie.org\",\"templated\":true,\"name\":\"cur\"}],\"self\":{\"href\":\"https://self.com\"}},\"a\":\"Test\"}";
-    assert_eq!(s,target);
-
-
- }
+    assert_eq!(s, target);
+}
 
 #[test]
 fn check_simple_resource_gets_deserialized() {
     let source = r#"{ "_links":{"self":{"href": "https://www.test.com"}}, "a": "123"}"#;
     let hal: HalResource = from_str(source).unwrap();
-    assert_eq!(hal.get_self() , Some(&HalLink::new("https://www.test.com")));
+    assert_eq!(hal.get_self(), Some(&HalLink::new("https://www.test.com")));
 }
 
 #[test]
 fn check_extra_fields_get_serialized() {
-    let mut f: HalResource = HalResource::new(Test1 { a: "Test".to_string() });
+    let mut f: HalResource = HalResource::new(Test1 {
+        a: "Test".to_string(),
+    });
     f.with_extra_data("int", 123);
     f.with_extra_data("string", "Hello!?");
     let s = to_string(&f).unwrap();
@@ -94,5 +110,5 @@ fn check_extra_fields_get_serialized() {
 fn check_extra_fields_get_deserialized() {
     let source = r#"{ "_links":{"self":{"href": "https://www.test.com"}}, "a": "123", "b":456}"#;
     let hal: HalResource = from_str(source).unwrap();
-    assert_eq!(hal.get_extra_data::<i32>("b").unwrap() , 456);
+    assert_eq!(hal.get_extra_data::<i32>("b").unwrap(), 456);
 }

--- a/src/tests/resource.rs
+++ b/src/tests/resource.rs
@@ -69,7 +69,7 @@ fn check_embedded_resource_gets_serialized() {
         a: "Test".to_string(),
     });
     f.with_link("self", "https://self.com")
-        .with_resource("child", &r1);
+        .with_resource("child", r1);
 
     let s = to_string(&f).unwrap();
     let target = "{\"_links\":{\"self\":{\"href\":\"https://self.com\"}},\"_embedded\":{\"child\":{\"_links\":{\"self\":{\"href\":\"https://self2.com\"}},\"a\":\"Test2\"}},\"a\":\"Test\"}";


### PR DESCRIPTION
`with_resources` takes a vector of resources (as opposed to a single resource in the case of 
 with_resource`) and ensures that the embedded resources are always contained in an array.