### PR TITLE
Remove custom de/serializer by using serde attributes properly

### DIFF
--- a/src/tests/link.rs
+++ b/src/tests/link.rs
@@ -27,7 +27,8 @@ fn ensure_full_link_gets_deserialized() {
    "deprecation": "https://www.google.com/deprecation",
    "title": "Google Search"
 }"#,
-    ).unwrap();
+    )
+    .unwrap();
 
     assert_eq!(link.href, "https://www.google.com");
     assert_eq!(link.name, Some("google".to_string()));


### PR DESCRIPTION
use serde attributes to modify the serialisation to suit, and thus removing a lot of custom serialisation code.